### PR TITLE
Add more finalization test cases

### DIFF
--- a/test/compiler_test.f90
+++ b/test/compiler_test.f90
@@ -80,11 +80,12 @@ contains
     !! Destructor for elem_t
     type(elem_t), intent(inout) :: self
     self % dummy = toggled_state
-    call increment_finalizations()
+    call increment(finalizations)
   end subroutine
 
-  subroutine increment_finalizations()
-    finalizations = finalizations + 1
+  pure subroutine increment(counter)
+    integer, intent(inout) :: counter
+    counter = counter + 1
   end subroutine
 
   function check_rhs_object_assignment() result(result_)

--- a/test/compiler_test.f90
+++ b/test/compiler_test.f90
@@ -53,6 +53,7 @@ contains
 
   function check_rhs_object_assignment() result(result_)
     !! Tests 7.5.6.3 case 1 (intrinsic assignment with non-allocatable variable)
+    !! Expected: 1; gfortran 11.2: 0
     type(object_t) :: lhs, rhs
     type(result_t) result_
     integer initial_tally, delta
@@ -66,6 +67,7 @@ contains
 
   function check_rhs_function_reference() result(result_)
     !! Tests 7.5.6.3 case 1 (intrinsic assignment with allocated variable)
+    !! Expected: 1; gfortran 11.2: 0
     type(object_t), allocatable  :: object
     type(result_t) result_
     integer initial_tally, delta

--- a/test/compiler_test.f90
+++ b/test/compiler_test.f90
@@ -57,7 +57,7 @@ contains
     !! Expected: 1; gfortran 11.2: 0
     type(object_t) :: lhs, rhs
     type(result_t) result_
-    integer initial_tally, delta
+    integer :: initial_tally, delta
 
     rhs%dummy = avoid_unused_variable_warning
     initial_tally = finalizations
@@ -71,7 +71,7 @@ contains
     !! Expected: 1; gfortran 11.2: 0
     type(object_t), allocatable  :: object
     type(result_t) result_
-    integer initial_tally, delta
+    integer :: initial_tally, delta
 
     initial_tally = finalizations
     object = object_t() ! finalizes object_t result
@@ -117,7 +117,7 @@ contains
     !! Tests 7.5.6.3 cases 2 (allocatable entity) & 7
     type(wrapper_t), allocatable  :: wrapper
     type(result_t) result_
-    integer initial_tally, delta
+    integer :: initial_tally, delta
 
     initial_tally = finalizations
 

--- a/test/compiler_test.f90
+++ b/test/compiler_test.f90
@@ -47,6 +47,7 @@ contains
 
   subroutine count_finalizations(self)
     type(object_t), intent(inout) :: self
+    print *, 'Finalizing...'
     finalizations = finalizations + 1
     self%dummy = avoid_unused_variable_warning
   end subroutine

--- a/test/compiler_test.f90
+++ b/test/compiler_test.f90
@@ -34,12 +34,12 @@ contains
         "The compiler", &
         [ it("finalizes a non-allocatable object on the LHS of an intrinsic assignment", check_lhs_object) & 
          ,it("finalizes an allocated allocatable LHS of an intrinsic assignment", check_allocated_allocatable_lhs) &
-         ,it("finalizes a function reference on the RHS of an intrinsic assignment", check_rhs_function_reference) &
          ,it("finalizes an object upon explicit deallocation", check_finalize_on_deallocate) &
-         ,it("finalizes an allocatable component object", check_allocatable_component_finalization) &
-         ,it("finalizes a non-pointer non-allocatable object at the end of a block construct", check_block_finalization) &
          ,it("finalizes a non-pointer non-allocatable array object at the END statement", check_finalize_on_end) &
+         ,it("finalizes a non-pointer non-allocatable object at the end of a block construct", check_block_finalization) &
+         ,it("finalizes a function reference on the RHS of an intrinsic assignment", check_rhs_function_reference) &
          ,it("finalizes an intent(out) derived type dummy argument", check_intent_out_finalization) &
+         ,it("finalizes an allocatable component object", check_allocatable_component_finalization) &
       ])
   end function
 
@@ -57,8 +57,7 @@ contains
   end subroutine
 
   function check_lhs_object() result(result_)
-    !! Tests 7.5.6.3, paragraph 1 (intrinsic assignment with non-allocatable LHS variable)
-    !! Expected: 1; gfortran 11.2: 0
+    !! Verify Fortran 2018 clause 7.5.6.3, paragraph 1 behavior
     type(object_t) lhs, rhs
     type(result_t) result_
     integer initial_tally
@@ -72,8 +71,7 @@ contains
   end function
 
   function check_allocated_allocatable_lhs() result(result_)
-    !! Tests 7.5.6.3, paragraph 1 (intrinsic assignment with non-allocatable LHS variable)
-    !! Expected: 1; gfortran 11.2: 0
+    !! Verify Fortran 2018 clause 7.5.6.3, paragraph 1 behavior
     type(object_t), allocatable :: lhs
     type(object_t) rhs
     type(result_t) result_
@@ -86,19 +84,6 @@ contains
     associate(delta => finalizations - initial_tally)
       result_ = assert_equals(1, delta)
     end associate
-  end function
-
-  function check_rhs_function_reference() result(result_)
-    !! Tests 7.5.6.3, paragraph 5 
-    !! Expected: 1; gfortran 11.2: 0
-    type(object_t), allocatable :: object
-    type(result_t) result_
-    integer initial_tally, delta
-
-    initial_tally = finalizations
-    object = object_t() ! finalizes object_t result
-    delta = finalizations - initial_tally
-    result_ = assert_equals(1, delta)
   end function
 
   function check_finalize_on_deallocate() result(result_)
@@ -146,6 +131,18 @@ contains
       type(object_t) object
       object % dummy = avoid_unused_variable_warning
     end block ! Finalizes object
+    delta = finalizations - initial_tally
+    result_ = assert_equals(1, delta)
+  end function
+
+  function check_rhs_function_reference() result(result_)
+    !! Verify Fortran 2018 clause 7.5.6.3, paragraph 5 behavior
+    type(object_t), allocatable :: object
+    type(result_t) result_
+    integer initial_tally, delta
+
+    initial_tally = finalizations
+    object = object_t() ! finalizes object_t result
     delta = finalizations - initial_tally
     result_ = assert_equals(1, delta)
   end function

--- a/test/compiler_test.f90
+++ b/test/compiler_test.f90
@@ -79,7 +79,6 @@ contains
   elemental subroutine count_elemental_finalizations(self)
     !! Destructor for elem_t
     type(elem_t), intent(inout) :: self
-    integer, intent(out) :: count
     self % dummy = toggled_state
   end subroutine
 

--- a/test/compiler_test.f90
+++ b/test/compiler_test.f90
@@ -7,7 +7,7 @@ module compiler_test
 
   type object_t
     private
-    integer :: dummy
+    integer dummy
   contains
     final :: count_finalizations
   end type
@@ -27,7 +27,7 @@ module compiler_test
 contains
 
   function test_ref_reference() result(tests)
-    type(test_item_t) :: tests
+    type(test_item_t) tests
 
     tests = &
       describe( &
@@ -44,7 +44,7 @@ contains
 
   function construct_object() result(object)
     !! Constructor for object_t
-    type(object_t) :: object
+    type(object_t) object
     object % dummy = avoid_unused_variable_warning
   end function
 
@@ -59,9 +59,9 @@ contains
   function check_rhs_object_assignment() result(result_)
     !! Tests 7.5.6.3 case 1 (intrinsic assignment with non-allocatable variable)
     !! Expected: 1; gfortran 11.2: 0
-    type(object_t) :: lhs, rhs
-    type(result_t) :: result_
-    integer :: initial_tally, delta
+    type(object_t) lhs, rhs
+    type(result_t) result_
+    integer initial_tally, delta
 
     rhs%dummy = avoid_unused_variable_warning
     initial_tally = finalizations
@@ -74,8 +74,8 @@ contains
     !! Tests 7.5.6.3 case 1 (intrinsic assignment with allocated variable)
     !! Expected: 1; gfortran 11.2: 0
     type(object_t), allocatable :: object
-    type(result_t) :: result_
-    integer :: initial_tally, delta
+    type(result_t) result_
+    integer initial_tally, delta
 
     initial_tally = finalizations
     object = object_t() ! finalizes object_t result
@@ -86,8 +86,8 @@ contains
   function check_finalize_on_deallocate() result(result_)
     !! Tests 7.5.6.3 case 2 (explicit deallocation on allocatable entity)
     type(object_t), allocatable :: object
-    type(result_t) :: result_
-    integer :: initial_tally
+    type(result_t) result_
+    integer initial_tally
 
     initial_tally = finalizations
     allocate(object)
@@ -100,9 +100,8 @@ contains
 
   function check_finalize_on_end() result(result_)
     !! Tests 7.5.6.3 case 3
-    type(result_t) :: result_
-    integer :: initial_tally
-    intrinsic :: count
+    type(result_t) result_
+    integer initial_tally
 
     initial_tally = finalizations
     call finalize_on_end_subroutine() ! Finalizes local_obj
@@ -113,7 +112,7 @@ contains
   contains
 
     subroutine finalize_on_end_subroutine()
-      type(object_t) :: local_obj
+      type(object_t) local_obj
       local_obj % dummy = avoid_unused_variable_warning
     end subroutine
 
@@ -121,12 +120,12 @@ contains
 
   function check_block_finalization() result(result_)
     !! Tests 7.5.6.3 case 4
-    type(result_t) :: result_
-    integer :: initial_tally, delta
+    type(result_t) result_
+    integer initial_tally, delta
 
     initial_tally = finalizations
     block
-      type(object_t) :: object
+      type(object_t) object
       object % dummy = avoid_unused_variable_warning
     end block ! Finalizes object
     delta = finalizations - initial_tally
@@ -135,9 +134,9 @@ contains
 
   function check_intent_out_finalization() result(result_)
     !! Tests 7.5.6.3 case 7 (non-pointer non-allocatable INTENT(OUT) dummy argument)
-    type(result_t) :: result_
-    type(object_t) :: object
-    integer :: initial_tally
+    type(result_t) result_
+    type(object_t) object
+    integer initial_tally
 
     initial_tally = finalizations
     call finalize_intent_out_arg(object)
@@ -155,8 +154,8 @@ contains
   function check_allocatable_component_finalization() result(result_)
     !! Tests 7.5.6.3 cases 2 (allocatable entity) & 7
     type(wrapper_t), allocatable :: wrapper
-    type(result_t) :: result_
-    integer :: initial_tally, delta
+    type(result_t) result_
+    integer initial_tally, delta
 
     initial_tally = finalizations
 

--- a/test/compiler_test.f90
+++ b/test/compiler_test.f90
@@ -51,7 +51,6 @@ contains
   subroutine count_finalizations(self)
     !! Destructor for object_t
     type(object_t), intent(inout) :: self
-    print *, 'Finalizing object...'
     finalizations = finalizations + 1
     self % dummy = avoid_unused_variable_warning
   end subroutine

--- a/test/compiler_test.f90
+++ b/test/compiler_test.f90
@@ -37,6 +37,7 @@ contains
          ,it("finalizes a non-allocatable object on the RHS of an intrinsic assignment", check_rhs_object_assignment) &
          ,it("finalizes a function reference on the RHS of an intrinsic assignment", check_rhs_function_reference) &
          ,it("finalizes an allocatable component object", check_allocatable_component_finalization) &
+         ,it("finalizes a non-pointer non-allocatable object at the end of a block construct", check_block_finalization) &
       ])
   end function
 
@@ -68,20 +69,6 @@ contains
     result_ = assert_equals(1, delta)
   end function
 
-  function check_block_finalization() result(result_)
-    !! Tests 7.5.6.3 case 4
-    type(result_t) :: result_
-    integer :: initial_tally, delta
-
-    initial_tally = finalizations
-    block
-      type(object_t) :: object
-      object % dummy = avoid_unused_variable_warning
-    end block ! Finalizes object
-    delta = finalizations - initial_tally
-    result_ = assert_equals(1, delta)
-  end function
-
   function check_rhs_function_reference() result(result_)
     !! Tests 7.5.6.3 case 1 (intrinsic assignment with allocated variable)
     !! Expected: 1; gfortran 11.2: 0
@@ -108,6 +95,20 @@ contains
     associate(final_tally => finalizations - initial_tally)
       result_ = assert_equals(1, final_tally)
     end associate
+  end function
+
+  function check_block_finalization() result(result_)
+    !! Tests 7.5.6.3 case 4
+    type(result_t) :: result_
+    integer :: initial_tally, delta
+
+    initial_tally = finalizations
+    block
+      type(object_t) :: object
+      object % dummy = avoid_unused_variable_warning
+    end block ! Finalizes object
+    delta = finalizations - initial_tally
+    result_ = assert_equals(1, delta)
   end function
 
   function check_intent_out_finalization() result(result_)

--- a/test/compiler_test.f90
+++ b/test/compiler_test.f90
@@ -75,7 +75,7 @@ contains
 
   elemental subroutine count_elemental_finalizations(self)
     !! Destructor for elem_t
-    type(elem_t), intent(out) :: self
+    type(elem_t), intent(inout) :: self
     !$omp atomic update
     finalizations = finalizations + 1
     !$omp end atomic

--- a/test/compiler_test.f90
+++ b/test/compiler_test.f90
@@ -41,7 +41,7 @@ contains
   end function
 
   function construct() result(object)
-    type(object_t) object
+    type(object_t) :: object
     object%dummy = avoid_unused_variable_warning
   end function
 
@@ -56,7 +56,7 @@ contains
     !! Tests 7.5.6.3 case 1 (intrinsic assignment with non-allocatable variable)
     !! Expected: 1; gfortran 11.2: 0
     type(object_t) :: lhs, rhs
-    type(result_t) result_
+    type(result_t) :: result_
     integer :: initial_tally, delta
 
     rhs%dummy = avoid_unused_variable_warning
@@ -70,7 +70,7 @@ contains
     !! Tests 7.5.6.3 case 1 (intrinsic assignment with allocated variable)
     !! Expected: 1; gfortran 11.2: 0
     type(object_t), allocatable  :: object
-    type(result_t) result_
+    type(result_t) :: result_
     integer :: initial_tally, delta
 
     initial_tally = finalizations
@@ -82,8 +82,8 @@ contains
   function check_finalize_on_deallocate() result(result_)
     !! Tests 7.5.6.3 case 2 (explicit deallocation on allocatable entity)
     type(object_t), allocatable  :: object
-    type(result_t) result_
-    integer initial_tally
+    type(result_t) :: result_
+    integer :: initial_tally
 
     initial_tally = finalizations
     allocate(object)
@@ -96,9 +96,9 @@ contains
 
   function check_intent_out_finalization() result(result_)
     !! Tests 7.5.6.3 case 7 (non-pointer non-allocatable INTENT(OUT) dummy argument)
-    type(result_t) result_
-    type(object_t) object
-    integer initial_tally
+    type(result_t) :: result_
+    type(object_t) :: object
+    integer :: initial_tally
 
     initial_tally = finalizations
     call finalize_intent_out_arg(object)
@@ -116,7 +116,7 @@ contains
   function check_allocatable_component_finalization() result(result_)
     !! Tests 7.5.6.3 cases 2 (allocatable entity) & 7
     type(wrapper_t), allocatable  :: wrapper
-    type(result_t) result_
+    type(result_t) :: result_
     integer :: initial_tally, delta
 
     initial_tally = finalizations

--- a/test/compiler_test.f90
+++ b/test/compiler_test.f90
@@ -15,11 +15,11 @@ module compiler_test
   type wrapper_t
     private
     type(object_t), allocatable  :: object
-  end type 
+  end type
 
   interface object_t
     module procedure  construct
-  end interface 
+  end interface
 
   integer :: finalizations = 0
   integer, parameter :: avoid_unused_variable_warning = 1
@@ -29,14 +29,14 @@ contains
   function test_ref_reference() result(tests)
     type(test_item_t) :: tests
 
-    tests = & 
+    tests = &
       describe( &
         "The compiler", &
         [ it("finalizes an intent(out) derived type dummy argument", check_intent_out_finalization) &
          ,it("finalizes an object upon explicit deallocation", check_finalize_on_deallocate) &
          ,it("finalizes a function reference on the RHS of an intrinsic assignment", check_rhs_function_reference) &
          ,it("finalizes an allocatable component object", check_allocatable_component_finalization) &
-      ])  
+      ])
   end function
 
   function construct() result(object)
@@ -46,11 +46,12 @@ contains
 
   subroutine count_finalizations(self)
     type(object_t), intent(inout) :: self
-    finalizations = finalizations + 1 
+    finalizations = finalizations + 1
     self%dummy = avoid_unused_variable_warning
   end subroutine
 
   function check_rhs_function_reference() result(result_)
+    !! Tests 7.5.6.3 case 1 (intrinsic assignment with allocated variable)
     type(object_t), allocatable  :: object
     type(result_t) result_
     integer initial_tally, delta
@@ -62,6 +63,7 @@ contains
   end function
 
   function check_finalize_on_deallocate() result(result_)
+    !! Tests 7.5.6.3 case 2 (explicit deallocation on allocatable entity)
     type(object_t), allocatable  :: object
     type(result_t) result_
     integer initial_tally
@@ -76,6 +78,7 @@ contains
   end function
 
   function check_intent_out_finalization() result(result_)
+    !! Tests 7.5.6.3 case 7 (non-pointer non-allocatable INTENT(OUT) dummy argument)
     type(result_t) result_
     type(object_t) object
     integer initial_tally
@@ -94,6 +97,7 @@ contains
   end function
 
   function check_allocatable_component_finalization() result(result_)
+    !! Tests 7.5.6.3 cases 2 (allocatable entity) & 7
     type(wrapper_t), allocatable  :: wrapper
     type(result_t) result_
     integer initial_tally, delta
@@ -115,5 +119,5 @@ contains
     end subroutine
 
   end function
-  
+
 end module compiler_test

--- a/test/compiler_test.f90
+++ b/test/compiler_test.f90
@@ -7,14 +7,14 @@ module compiler_test
 
   type object_t
     private
-    integer dummy
+    integer :: dummy
   contains
     final :: count_finalizations
   end type
 
   type wrapper_t
     private
-    type(object_t), allocatable  :: object
+    type(object_t), allocatable :: object
   end type
 
   interface object_t

--- a/test/compiler_test.f90
+++ b/test/compiler_test.f90
@@ -76,7 +76,6 @@ contains
   elemental subroutine count_elemental_finalizations(self)
     !! Destructor for elem_t
     type(elem_t), intent(out) :: self
-    print *, 'Finalizing element...'
     !$omp atomic update
     finalizations = finalizations + 1
     !$omp end atomic

--- a/test/compiler_test.f90
+++ b/test/compiler_test.f90
@@ -34,6 +34,7 @@ contains
         "The compiler", &
         [ it("finalizes an intent(out) derived type dummy argument", check_intent_out_finalization) &
          ,it("finalizes an object upon explicit deallocation", check_finalize_on_deallocate) &
+         ,it("finalizes a non-allocatable object on the RHS of an intrinsic assignment", check_rhs_object_assignment) &
          ,it("finalizes a function reference on the RHS of an intrinsic assignment", check_rhs_function_reference) &
          ,it("finalizes an allocatable component object", check_allocatable_component_finalization) &
       ])
@@ -49,6 +50,19 @@ contains
     finalizations = finalizations + 1
     self%dummy = avoid_unused_variable_warning
   end subroutine
+
+  function check_rhs_object_assignment() result(result_)
+    !! Tests 7.5.6.3 case 1 (intrinsic assignment with non-allocatable variable)
+    type(object_t) :: lhs, rhs
+    type(result_t) result_
+    integer initial_tally, delta
+
+    rhs%dummy = avoid_unused_variable_warning
+    initial_tally = finalizations
+    lhs = rhs ! finalizes rhs
+    delta = finalizations - initial_tally
+    result_ = assert_equals(1, delta)
+  end function
 
   function check_rhs_function_reference() result(result_)
     !! Tests 7.5.6.3 case 1 (intrinsic assignment with allocated variable)

--- a/test/compiler_test.f90
+++ b/test/compiler_test.f90
@@ -29,6 +29,7 @@ contains
         "The compiler", &
         [ it("finalizes a non-allocatable object on the LHS of an intrinsic assignment", check_lhs_object) & 
          ,it("finalizes an allocated allocatable LHS of an intrinsic assignment", check_allocated_allocatable_lhs) &
+         ,it("finalizes a target when the associated pointer is deallocated", check_target_deallocation) &
          ,it("finalizes an object upon explicit deallocation", check_finalize_on_deallocate) &
          ,it("finalizes a non-pointer non-allocatable array object at the END statement", check_finalize_on_end) &
          ,it("finalizes a non-pointer non-allocatable object at the end of a block construct", check_block_finalization) &
@@ -53,7 +54,7 @@ contains
   end subroutine
 
   function check_lhs_object() result(result_)
-    !! Verify Fortran 2018 clause 7.5.6.3, paragraph 1 behavior
+    !! Verify Fortran 2018 clause 7.5.6.3, paragraph 1 behavior: "not an unallocated allocatable variable"
     type(object_t) lhs, rhs
     type(result_t) result_
     integer initial_tally
@@ -67,7 +68,7 @@ contains
   end function
 
   function check_allocated_allocatable_lhs() result(result_)
-    !! Verify Fortran 2018 clause 7.5.6.3, paragraph 1 behavior
+    !! Verify Fortran 2018 clause 7.5.6.3, paragraph 1 behavior: "allocated allocatable variable"
     type(object_t), allocatable :: lhs
     type(object_t) rhs
     type(result_t) result_
@@ -82,109 +83,23 @@ contains
     end associate
   end function
 
-  function check_finalize_on_deallocate() result(result_)
-    !! Tests 7.5.6.3, paragraph 2 (explicit deallocation on allocatable entity)
-    type(object_t), allocatable :: object
+  function check_target_deallocation() result(result_)
+    !! Verify Fortran 2018 clause 7.5.6.3, paragraph 2 behavior: "pointer is deallocated"
+    type(object_t), pointer :: object_ptr => null()
     type(result_t) result_
     integer initial_tally
 
+    allocate(object_ptr, source=object_t(dummy=0))
     initial_tally = finalizations
-    allocate(object)
-    object%dummy = 1
-    deallocate(object)          ! finalizes object
-    associate(final_tally => finalizations - initial_tally)
-      result_ = assert_equals(1, final_tally)
-    end associate
-  end function
-
-  function check_finalize_on_end() result(result_)
-    !! Tests 7.5.6.3, paragraph 3
-    type(result_t) result_
-    integer initial_tally
-
-    initial_tally = finalizations
-    call finalize_on_end_subroutine() ! Finalizes local_obj
-    associate(final_tally => finalizations - initial_tally)
-      result_ = assert_equals(1, final_tally)
-    end associate
-
-  contains
-
-    subroutine finalize_on_end_subroutine()
-      type(object_t) local_obj
-      local_obj % dummy = avoid_unused_variable_warning
-    end subroutine
-
-  end function
-
-  function check_block_finalization() result(result_)
-    !! Tests 7.5.6.3, paragraph 4
-    type(result_t) result_
-    integer initial_tally
-
-    initial_tally = finalizations
-    block
-      type(object_t) object
-      object % dummy = avoid_unused_variable_warning
-    end block ! Finalizes object
+    deallocate(object_ptr) ! finalizes object
     associate(delta => finalizations - initial_tally)
       result_ = assert_equals(1, delta)
     end associate
-  end function
-
-  function check_rhs_function_reference() result(result_)
-    !! Verify Fortran 2018 clause 7.5.6.3, paragraph 5 behavior
-    type(object_t), allocatable :: object
-    type(result_t) result_
-    integer initial_tally
-
-    initial_tally = finalizations
-    object = construct_object() ! finalizes object_t result
-    associate(delta => finalizations - initial_tally)
-      result_ = assert_equals(1, delta)
-    end associate
-  end function
-
-  function check_specification_expression() result(result_)
-    !! Tests 7.5.6.3, paragraph 6 
-    type(result_t) result_
-    integer initial_tally
-
-    initial_tally = finalizations
-    call finalize_specification_expression
-    associate(delta => finalizations - initial_tally)
-      result_ = assert_equals(1, delta)
-    end associate
-
-  contains
-
-    subroutine finalize_specification_expression
-      type(object_t) :: object = object_t(dummy=0) ! Finalizes RHS function reference
-      object%dummy = avoid_unused_variable_warning
-    end subroutine
-
-  end function
-
-  function check_intent_out_finalization() result(result_)
-    !! Tests 7.5.6.3, paragraph 7 (non-pointer non-allocatable INTENT(OUT) dummy argument)
-    type(result_t) result_
-    type(object_t) object
-    integer initial_tally
-
-    initial_tally = finalizations
-    call finalize_intent_out_arg(object)
-    associate(delta => finalizations - initial_tally)
-      result_ = assert_equals(1, delta)
-    end associate
-  contains
-    subroutine finalize_intent_out_arg(output)
-      type(object_t), intent(out) :: output ! finalizes output
-      output%dummy = avoid_unused_variable_warning
-    end subroutine
   end function
 
   function check_allocatable_component_finalization() result(result_)
-    !! Tests 7.5.6.3, paragraph 2 (allocatable entity) & 7
+    !! Tests 7.5.6.3, para. 2 ("allocatable entity is deallocated") 
+    !! + 9.7.3.2, para. 6 ("INTENT(OUT) allocatable dummy argument is deallocated")
     type(wrapper_t), allocatable :: wrapper
     type(result_t) result_
     integer initial_tally
@@ -206,6 +121,107 @@ contains
       output%object%dummy = avoid_unused_variable_warning
     end subroutine
 
+  end function
+
+  function check_finalize_on_deallocate() result(result_)
+    !! Tests 7.5.6.3, paragraph 2: "allocatable entity is deallocated"
+    type(object_t), allocatable :: object
+    type(result_t) result_
+    integer initial_tally
+
+    initial_tally = finalizations
+    allocate(object)
+    object%dummy = 1
+    deallocate(object)          ! finalizes object
+    associate(final_tally => finalizations - initial_tally)
+      result_ = assert_equals(1, final_tally)
+    end associate
+  end function
+
+  function check_finalize_on_end() result(result_)
+    !! Tests 7.5.6.3, paragraph 3: "before return or END statement"
+    type(result_t) result_
+    integer initial_tally
+
+    initial_tally = finalizations
+    call finalize_on_end_subroutine() ! Finalizes local_obj
+    associate(final_tally => finalizations - initial_tally)
+      result_ = assert_equals(1, final_tally)
+    end associate
+
+  contains
+
+    subroutine finalize_on_end_subroutine()
+      type(object_t) local_obj
+      local_obj % dummy = avoid_unused_variable_warning
+    end subroutine
+
+  end function
+
+  function check_block_finalization() result(result_)
+    !! Tests 7.5.6.3, paragraph 4: "termination of the BLOCK construct"
+    type(result_t) result_
+    integer initial_tally
+
+    initial_tally = finalizations
+    block
+      type(object_t) object
+      object % dummy = avoid_unused_variable_warning
+    end block ! Finalizes object
+    associate(delta => finalizations - initial_tally)
+      result_ = assert_equals(1, delta)
+    end associate
+  end function
+
+  function check_rhs_function_reference() result(result_)
+    !! Verify Fortran 2018 clause 7.5.6.3, paragraph 5 behavior: "nonpointer function result"
+    type(object_t), allocatable :: object
+    type(result_t) result_
+    integer initial_tally
+
+    initial_tally = finalizations
+    object = construct_object() ! finalizes object_t result
+    associate(delta => finalizations - initial_tally)
+      result_ = assert_equals(1, delta)
+    end associate
+  end function
+
+  function check_specification_expression() result(result_)
+    !! Tests 7.5.6.3, paragraph 6: "specification expression function result"
+    type(result_t) result_
+    integer initial_tally
+
+    initial_tally = finalizations
+    call finalize_specification_expression
+    associate(delta => finalizations - initial_tally)
+      result_ = assert_equals(1, delta)
+    end associate
+
+  contains
+
+    subroutine finalize_specification_expression
+      type(object_t) :: object = object_t(dummy=0) ! Finalizes RHS function reference
+      object%dummy = avoid_unused_variable_warning
+    end subroutine
+
+  end function
+
+  function check_intent_out_finalization() result(result_)
+    !! Tests 7.5.6.3, paragraph 7: "nonpointer, nonallocatable, INTENT (OUT) dummy argument"
+    type(result_t) result_
+    type(object_t) object
+    integer initial_tally
+
+    initial_tally = finalizations
+    call finalize_intent_out_arg(object)
+    associate(delta => finalizations - initial_tally)
+      result_ = assert_equals(1, delta)
+    end associate
+  contains
+    subroutine finalize_intent_out_arg(output)
+      type(object_t), intent(out) :: output ! finalizes output
+      output%dummy = avoid_unused_variable_warning
+    end subroutine
   end function
 
 end module compiler_test

--- a/test/compiler_test.f90
+++ b/test/compiler_test.f90
@@ -21,22 +21,8 @@ module compiler_test
     type(object_t), allocatable :: object
   end type
 
-  type elem_t
-    private
-    integer :: dummy
-  contains
-    final :: count_elemental_finalizations
-  end type
-
-  interface elem_t
-    module procedure construct_elem
-  end interface elem_t
-
   integer :: finalizations = 0
   integer, parameter :: avoid_unused_variable_warning = 1
-  integer, parameter :: toggled_state = -1
-
-  integer, parameter :: nelems = 2
 
 contains
 
@@ -68,24 +54,6 @@ contains
     print *, 'Finalizing object...'
     finalizations = finalizations + 1
     self % dummy = avoid_unused_variable_warning
-  end subroutine
-
-  elemental function construct_elem() result(elem)
-    !! Constructor for elem_t
-    type(elem_t) :: elem
-    elem % dummy = avoid_unused_variable_warning
-  end function
-
-  elemental subroutine count_elemental_finalizations(self)
-    !! Destructor for elem_t
-    type(elem_t), intent(inout) :: self
-    self % dummy = toggled_state
-    call increment(finalizations)
-  end subroutine
-
-  pure subroutine increment(counter)
-    integer, intent(inout) :: counter
-    counter = counter + 1
   end subroutine
 
   function check_rhs_object_assignment() result(result_)
@@ -137,16 +105,16 @@ contains
     intrinsic :: count
 
     initial_tally = finalizations
-    call finalize_on_end_subroutine() ! Finalizes local_array
+    call finalize_on_end_subroutine() ! Finalizes local_obj
     associate(final_tally => finalizations - initial_tally)
-      result_ = assert_equals(nelems, final_tally)
+      result_ = assert_equals(1, final_tally)
     end associate
 
   contains
 
     subroutine finalize_on_end_subroutine()
-      type(elem_t) :: local_array(nelems)
-      local_array % dummy = avoid_unused_variable_warning
+      type(object_t) :: local_obj
+      local_obj % dummy = avoid_unused_variable_warning
     end subroutine
 
   end function


### PR DESCRIPTION
Covers Fortran 2018 standard, clause 7.5.6.3, paragraphs 1-7.
(Paragraph 8 is "processor dependent")