### PR TITLE
Add smart_pointer example in test folder

### DIFF
--- a/src/reference_counter/ref_counter_m.f90
+++ b/src/reference_counter/ref_counter_m.f90
@@ -10,6 +10,7 @@ module ref_counter_m
     integer, pointer :: count_ => null()
     class(ref_resource_t), pointer :: object_ => null()
   contains
+    procedure :: reference_count
     procedure, non_overridable :: grab
     procedure, non_overridable :: release
     procedure :: assign_ref_counter
@@ -28,6 +29,12 @@ module ref_counter_m
   end interface
 
   interface
+
+    pure module function reference_count(self) result(counter)
+      implicit none
+      class(ref_counter_t), intent(in) :: self
+      integer counter
+    end function
 
     module subroutine grab(self)
       implicit none

--- a/src/reference_counter/ref_counter_s.f90
+++ b/src/reference_counter/ref_counter_s.f90
@@ -4,6 +4,10 @@ submodule(ref_counter_m) ref_counter_s
 
 contains
 
+  module procedure reference_count
+    counter = self%count_
+  end procedure
+
   module procedure construct
     allocate(ref_counter%count_, source=0)
     allocate(ref_counter%object_, source=object)

--- a/src/reference_counter/ref_reference_m.f90
+++ b/src/reference_counter/ref_reference_m.f90
@@ -9,11 +9,18 @@ module ref_reference_m
   type, abstract, extends(ref_resource_t) :: ref_reference_t
     type(ref_counter_t) :: ref_counter
   contains
+    procedure :: reference_count
     procedure, non_overridable :: release_handle
     procedure, non_overridable :: start_ref_counter
   end type
 
   interface
+
+    pure module function reference_count(self) result(counter)
+      implicit none
+      class(ref_reference_t), intent(in) :: self
+      integer counter
+    end function
 
     module subroutine release_handle(self)
       implicit none

--- a/src/reference_counter/ref_reference_s.f90
+++ b/src/reference_counter/ref_reference_s.f90
@@ -3,6 +3,10 @@ submodule(ref_reference_m) ref_reference_s
 
 contains
 
+  module procedure reference_count
+    counter = self%ref_counter%reference_count()
+  end procedure
+
   module procedure release_handle
     call self%ref_counter%release
   end procedure

--- a/test/smart_pointer.f90
+++ b/test/smart_pointer.f90
@@ -1,0 +1,99 @@
+module foo_m
+  implicit none
+
+  private
+  public :: foo_t
+
+  type foo_t
+  end type
+
+end module
+
+module smart_pointer_m
+  use reference_counter_m, only: ref_reference_t
+  use foo_m, only : foo_t
+
+  implicit none
+  private
+  public :: smart_pointer_t
+
+  type, extends(ref_reference_t) :: smart_pointer_t
+    type(foo_t), pointer :: ref => null()
+  contains
+    procedure :: free
+  end type
+
+  interface smart_pointer_t
+
+    module function construct(foo) result(smart_pointer)
+      implicit none
+      type(foo_t), intent(in), target :: foo
+      type(smart_pointer_t) :: smart_pointer
+    end function
+
+  end interface
+
+  interface
+
+    module subroutine free(self)
+      implicit none
+      class(smart_pointer_t), intent(inout) :: self
+    end subroutine
+
+  end interface
+
+end module
+
+submodule(smart_pointer_m) smart_pointer_s
+  implicit none
+
+contains
+
+  module procedure construct
+    smart_pointer%ref => foo
+    call smart_pointer%start_ref_counter
+  end procedure
+
+  module procedure free
+    if (associated(self%ref)) then
+      deallocate(self%ref)
+      nullify(self%ref)
+      print *,"free(): foo deallocated"
+    end if
+  end procedure
+
+end submodule
+
+program main
+  use smart_pointer_m, only : smart_pointer_t
+  use foo_m, only : foo_t
+  implicit none
+
+  block 
+
+    type(smart_pointer_t) ptr_1, ptr_2
+    type(foo_t), pointer :: foo => null()
+
+    allocate(foo, source = foo_t())
+    ptr_1 = smart_pointer_t(foo)  ! 1st reference
+    print *, ptr_1%reference_count() 
+    ptr_2 = ptr_1 ! 2nd reference
+    print *, ptr_2%reference_count()
+    call new_reference(ptr_2)
+    print *, ptr_2%reference_count() ! 2 remaining references
+
+  end block ! ref_reference_counter frees the memory after the 2 remaining references go out of scope
+
+  print *,"All references gone"
+
+contains
+
+  subroutine new_reference(obj)
+    type(smart_pointer_t), intent(in) :: obj
+    type(smart_pointer_t) local_ptr
+
+    local_ptr = obj                     ! 3rd reference
+    print *, local_ptr%reference_count()
+  end subroutine
+
+end program


### PR DESCRIPTION
The new file test/smart_pointer.f90 actually belongs in the example/ folder, but putting it there causes a perplexing test failure when testing with the command
```
fpm test --compiler nagfor --flag -fpp
```