### PR TITLE
Fix IBM XL Fortran build

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ fpm test --compiler nagfor --flag -fpp
 
 ### IBM (`xlf2003_r`)
 ```
-fpm test --compiler xlf2003_r
+fpm test --compiler xlf2003_r --flag -DXLF
 ```
 
 ### Intel (`ifort`)

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ fpm test --compiler xlf2003_r --flag -DXLF
 
 ### Intel (`ifort`)
 ```
-fpm test --compiler ifort --flag -coarray=shared
+fpm test --compiler ifort --flag
 ```
 
 ### GCC (`gfortran`)

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,9 +1,6 @@
-name = "reference_counter"
-version = "1.0.0"
+name = "smart_pointers"
+version = "2.1.0"
 license = "BSD"
 author = ["Damian Rouson, Karla Morris, and Jim Xia"]
 maintainer = "damian@archaeologic.codes"
 copyright = "2020-2022 Sourcery Institute"
-
-[dependencies]
-assert = {git = "https://github.com/sourceryinstitute/assert", tag = "1.3.0"}

--- a/src/smart_pointer/assert_m.F90
+++ b/src/smart_pointer/assert_m.F90
@@ -1,0 +1,26 @@
+module assert_m
+  !! Enforce logical assertions that can be toggled on/off at compile-time
+  !! To turn off assertions, building with the flag -DUSE_ASSERTIONS=.false.
+  implicit none
+
+  private
+  public :: assert
+
+#ifndef USE_ASSERTIONS
+# define USE_ASSERTIONS .true.
+#endif
+  logical, parameter :: enforce_assertions = USE_ASSERTIONS
+
+  interface 
+
+     pure module subroutine assert(assertion, description)
+       !! Error terminate on .false. assertion with the stop code given by description
+       !! With IBM XL Fortran, the stop code is an integer due to for character stop codes being unsupported.
+       implicit none
+       logical, intent(in) :: assertion
+       character(len=*), intent(in) :: description
+     end subroutine
+
+  end interface
+
+end module assert_m

--- a/src/smart_pointer/assert_s.F90
+++ b/src/smart_pointer/assert_s.F90
@@ -1,0 +1,18 @@
+submodule(assert_m) assert_s
+  implicit none
+
+contains
+
+  module procedure assert
+
+    if (enforce_assertions) then
+#ifdef XLF
+      if (.not. assertion) error stop 999
+#else
+      if (.not. assertion) error stop description
+#endif
+    end if
+
+  end procedure
+
+end submodule assert_s

--- a/src/smart_pointer/sp_smart_pointer_s.F90
+++ b/src/smart_pointer/sp_smart_pointer_s.F90
@@ -1,4 +1,7 @@
 submodule(sp_smart_pointer_m) sp_smart_pointer_s
+#ifdef XLF
+  use sp_reference_counter_m, only : sp_reference_counter_t 
+#endif
   implicit none
 
 contains

--- a/test/compiler_test_m.f90
+++ b/test/compiler_test_m.f90
@@ -232,7 +232,9 @@ contains
         else if (scan(compiler_identity, "NAG")==1) then
           args = "--compiler nagfor --flag -fpp"
         else if (scan(compiler_identity, "Intel")==1) then
-          args = "--compiler ifort --flag -coarray=shared"
+          args = "--compiler ifort --flag"
+        else if (scan(compiler_identity, "IBM")==1) then
+          args = "--compiler xlf2003_r --flag -DXLF"
         else
           error stop "----> Unrecognized compiler_version() in function fpm_compiler_arguments. <----"
         end if

--- a/test/test_m.F90
+++ b/test/test_m.F90
@@ -38,6 +38,9 @@ module test_m
 end module test_m
 
 submodule(test_m) test_s
+#ifdef XLF
+  use test_result_m, only : test_result_t
+#endif
   implicit none
 
 contains


### PR DESCRIPTION
This PR
1. Replaces the one remaining dependency, Assert, with a minimal assertion utility that IBM XL Fortran can compile due to the XL Fortran compiler's lack of support Fortran for 2008 `this_image()`.
2. Adds C preprocessor macros that work around various other XL Fortran issues.