### PR TITLE
Add IBM XL Fortran compile command to fpm_compiler_arguments function

### DIFF
--- a/test/compiler_test_m.f90
+++ b/test/compiler_test_m.f90
@@ -237,6 +237,8 @@ contains
           args = "--archiver ar --compiler xlf2008_r --flag -DXLF"
         else if (index(compiler_identity, "Cray")==1) then
           args = "--compiler ftn"
+        else if (index(compiler_identity, "XLF")==1) then
+          args = "--compiler xlf2008_r"
         else
           error stop "----> Unrecognized compiler_version() in function fpm_compiler_arguments. <----"
         end if


### PR DESCRIPTION
This PR ensures that the `check_specification_expression()` function in the `compiler_test_m` module recognizes and is able to invoke the IBM XL Fortran compile using `execute_command_line` subroutine, which is required because the only standard-conforming way to observe type finalization in a specification expression is through error termination (because the final subroutine must be `pure` and therefore can't do I/O).