### PR TITLE
Debug and new example

### DIFF
--- a/example/user_object_ab_smart_pointer.f90
+++ b/example/user_object_ab_smart_pointer.f90
@@ -1,0 +1,109 @@
+module user_object_m
+  use smart_pointer_m, only: sp_smart_pointer_t
+  implicit none
+
+  private
+  public :: user_object_t, user_object_ptr_t
+
+  type user_object_t
+    integer, allocatable :: i
+  contains
+    final :: uo_finalize
+  end type
+
+  type, extends(sp_smart_pointer_t) :: user_object_ptr_t
+    type(user_object_t), pointer :: ref => null()
+  contains
+    procedure :: free
+  end type
+
+  interface user_object_ptr_t
+
+    module function construct(user_object) result(user_object_ptr)
+      implicit none
+      type(user_object_t), intent(inout), pointer:: user_object
+      type(user_object_ptr_t) :: user_object_ptr
+    end function
+
+  end interface
+
+  interface
+
+    module subroutine free(self)
+      implicit none
+      class(user_object_ptr_t), intent(inout) :: self
+    end subroutine
+
+  end interface
+contains
+  subroutine uo_finalize(this)
+    type(user_object_t), intent(inout) :: this
+    deallocate(this%i)
+  end subroutine uo_finalize
+end module
+
+submodule(user_object_m) user_object_ptr_s
+  use assert_m, only : assert
+  implicit none
+
+contains
+
+  module procedure construct
+    call assert(associated(user_object), "construct_from_pointer: associated(user_object)")
+    user_object_ptr%ref => user_object
+    nullify(user_object)
+    call user_object_ptr%start_counter
+  end procedure
+
+  module procedure free
+    if (associated(self%ref)) then
+      deallocate(self%ref)
+      nullify(self%ref)
+      print *,"free(): user_object deallocated"
+    end if
+  end procedure
+
+end submodule
+
+program main
+  use user_object_m, only : user_object_t, user_object_ptr_t
+  use assert_m, only : assert
+  implicit none
+
+  block 
+    type(user_object_ptr_t) smart_pointer_1, smart_pointer_2
+    type(user_object_t), pointer :: user_object => null()
+
+    print *, "Allocating user_object pointer."
+    allocate(user_object, source = user_object_t())
+    allocate(user_object%i, source=1)
+    print *, "Defining smart_pointer_1."
+    smart_pointer_1 = user_object_ptr_t(user_object)
+    call assert(.not. associated(user_object), "main: .not. associated(user_object)")
+    print *, "Reference count = ", smart_pointer_1%reference_count()
+    print *, "Copying smart_pointer_1 into smart_pointer_2."
+
+    smart_pointer_2 = smart_pointer_1
+    print *, "Reference count = ", smart_pointer_1%reference_count()
+    call assert(smart_pointer_1%reference_count()==smart_pointer_2%reference_count(), "main: consistent counts")
+
+    call new_reference(smart_pointer_2)
+    call assert(smart_pointer_1%reference_count()==smart_pointer_2%reference_count(), "main: consistent counts")
+    print *, "Reference count = ", smart_pointer_1%reference_count()
+    print *, "smart_pointer_1 and smart_pointer_2 going out of scope"
+  end block
+
+contains
+
+  subroutine new_reference(dummy_argument)
+    type(user_object_ptr_t), intent(in) :: dummy_argument
+    type(user_object_ptr_t) smart_pointer_3 
+
+    print *, "Copying smart_pointer_2 into smart_pointer_3."
+    smart_pointer_3 = dummy_argument
+    call assert(dummy_argument%reference_count()==smart_pointer_3%reference_count(), "consistent counts")
+    print *, "Reference count = ", smart_pointer_3%reference_count()
+    print *, "smart_pointer_3 going out of scope."
+  end subroutine
+
+end program

--- a/src/smart_pointer/sp_reference_counter_s.f90
+++ b/src/smart_pointer/sp_reference_counter_s.f90
@@ -22,13 +22,16 @@ contains
 
   module procedure release
 
-    call assert(associated(self%count_),"sp_reference_counter_t%grab: associated(self%count_)")
-
+    call assert(associated(self%count_),"sp_reference_counter_t%release: associated(self%count_)")
+    write(0,*) associated(self%count_)
     self%count_ = self%count_ - 1
-
+    write(0,*) 'self%count: ',self%count_
     if (self%count_ == 0) then
+      write(0,*) 'release: deallocating '
       call self%object_%free
       deallocate (self%count_, self%object_)
+      self%count_ => null()
+      self%object_ => null()
     else
       self%count_ => null()
       self%object_ => null()


### PR DESCRIPTION
The new test program gives 
``` T
 self%count:            0
 release: deallocating 
 free(): user_object deallocated
 T
 self%count:            0
 release: deallocating 
free(): double free detected in tcache 2

Program received signal SIGABRT: Process abort signal.
```
The old gives 
```[sfilippone@didatticaSCPA example]$ ./user_object_smart_pointer 
 Allocating user_object pointer.
 Defining smart_pointer_1.
 T
 self%count:            1
 Reference count =            2
 Copying smart_pointer_1 into smart_pointer_2.
 Reference count =            3
 Copying smart_pointer_2 into smart_pointer_3.
 Reference count =            4
 smart_pointer_3 going out of scope.
 T
 self%count:            3
 T
 self%count:            2
 Reference count =            2
 smart_pointer_1 and smart_pointer_2 going out of scope
 T
 self%count:            1
 T
 self%count:            0
 release: deallocating 
 free(): user_object deallocated
 T
 self%count:     33040655
 T
 self%count:     33040655
 T
 self%count:     33040655
```
which points to something wrong in the RELEASE invocation. 

