### PR TITLE
fix(test): update docs & rm gfortran workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,18 +67,19 @@ summarizes the observed compiler behaviors:
 | _Compiler_   | _Test failures_    | _Version tested_                                    |
 | :---         |       :---:        | :---                                                |
 | AMD          | N.A. (see Note 1.) | `flang` 13.0.0 (AOCC_3.2.0-Build\#128 2021\_11\_12) |
-| Cray         | >= 3 (see Note 3.) | `ftn` 13.0.1                                        |
-| GCC          |         6          | `gfortran` 12.2.0                                   |
-| IBM          |         1          | `xlf2008_r` 17.1.0 on AIX                           |
-| Intel        |         1          | `ifort` 2021.7.0 Build 20220726_000000              |
-| LLVM         | N.A. (see Note 2.) | `git` commit `f5253058144aca1e9fcacd` (9/20/2022)   
-| NAG :trophy: |         0          | `nagfor` 7.1 Build 7113                             |
-| NVIDIA       |         2          | `nvfortran` 22.7-0                                  |
+| Cray         | >= 3 (see Note 2.) | `ftn` 13.0.1                                        |
+| GCC :trophy: | 0    (see Note 3.) | `gfortran` 13.0.1 20230321 (experimental)           |
+| IBM          | 1                  | `xlf2008_r` 17.1.0 on AIX                           |
+| Intel        | 1                  | `ifort` 2021.7.0 Build 20220726_000000              |
+| LLVM         | N.A. (see Note 4.) | `git` commit `f5253058144aca1e9fcacd` (9/20/2022)   
+| NAG :trophy: | 0                  | `nagfor` 7.1 Build 7113                             |
+| NVIDIA       | 2                  | `nvfortran` 22.7-0                                  |
 
 **Notes**
 1. Fails to build due to an internal compiler error (ICE).
-2. Fails to build due to type finalization not yet being supported.
 2. Fails to build due to `fpm` issue [767]. See [test/README.md#cray] for a lower bound on the Cray compiler test failures.
+3. See [test/README.md#gnu](./test/README.md#gnu) for instructions on building a current GCC from source.
+4. Fails to build due to type finalization not yet being supported.
 
 See the [test suite README.md](./test/README.md) for more details on each compiler's test
 results.

--- a/test/README.md
+++ b/test/README.md
@@ -15,7 +15,7 @@ Summary
 
 * [AMD](#amd): unsupported (fails to build Smart-Pointers)
 * [Cray](#cray): partial support (3 test failures)
-* [GCC](#gnu): partial support (6 test failures)
+* [GCC](#gnu): full support :trophy:
 * [IBM](#ibm): partial support (1 test failure)
 * [Intel](#intel): partial support (1 test failure)
 * [LLVM](#llvm): unsupported (fails to build Smart-Pointers)
@@ -57,31 +57,43 @@ ftn compile_me_only.f90
 The number of unit test failures for the remainder of the Smart-Pointers test suite is unknown.
 
 ### GCC
-- Version: 12.2.0
-- Result: 4 test failures.
+- Version: 13.0.1 20230321 (experimental)
+- Result: 0 test failures.
 ```
  % fpm test
 Project is up to date
 
  The compiler
-   Fail: finalizes a non-allocatable object on the LHS of an intrinsic assignment
-   Fail: finalizes an allocated allocatable LHS of an intrinsic assignment
+   Pass: finalizes a non-allocatable object on the LHS of an intrinsic assignment
+   Pass: finalizes an allocated allocatable LHS of an intrinsic assignment
    Pass: finalizes a target when the associated pointer is deallocated
    Pass: finalizes an object upon explicit deallocation
    Pass: finalizes a non-pointer non-allocatable object at the END statement
    Pass: finalizes a non-pointer non-allocatable object at END BLOCK statement
-   Fail: finalizes a function reference on the RHS of an intrinsic assignment
-   Fail: finalizes a specification expression function result
+   Pass: finalizes a function reference on the RHS of an intrinsic assignment
+   Pass: finalizes a specification expression function result
    Pass: finalizes an intent(out) derived type dummy argument
    Pass: finalizes an allocatable component object
 
  A smart_pointer
-   (skipped copy of declared reference due to a gfortran bug that would cause a segmentation fault)
    Pass: creates a resource when constructed
    Pass: removes the resource when the object goes out of scope
-   Fail: copy points to the same resource as the original
-   Fail: has zero references after a shallow copy goes out of scope
+   Pass: copy points to the same resource as the original
+   Pass: has zero references after a shallow copy goes out of scope
 ```
+
+The above gfortran version was built from source using commands of the following form:
+```
+git clone git@github.com:sourceryinstitute/opencoarrays
+cd opencoarrays
+./install.sh -p gcc -b master -j <num-threads>
+export LD_LIBRARY_PATH="${PWD}/prerequisites/installations/lib"
+export PATH="${PWD}/prerequisites/installations/bin:$PATH"
+```
+after replacing `<num-threads>` with the desired number of threads for an accelerated,
+multithreaded build.  Producing the above test results requires GCC commit
+[d7caf313525a46f200d7f5db1ba893f853774aee], which reduced the number of gfortran test
+failures from six to zero.
 
 ### IBM
 - Version: IBM Open XL Fortran for AIX 17.1.0 
@@ -176,3 +188,4 @@ Project is up to date
 [compiler_test_m.f90]:  ./compiler_test_m.f90
 [sp_smart_pointer_test_m.f90]:  ./sp_smart_pointer_test_m.F90
 [branch]: https://github.com/BerkeleyLab/llvm-test-suite/tree/fortran-type-finalization/Fortran/UnitTests/finalization
+[d7caf313525a46f200d7f5db1ba893f853774aee]: https://github.com/gcc-mirror/gcc/commit/5889c7bd46a45dc07ffb77ec0d698e18e0b99840 

--- a/test/sp_smart_pointer_test_m.F90
+++ b/test/sp_smart_pointer_test_m.F90
@@ -103,16 +103,9 @@ contains
       block 
         type(object_t) :: declared, reference_to_declared
 
-        if (scan(compiler_version(),"GCC ")==1) then
-          test_passes = associated(original%ref, reference%ref) .and. .false. ! intentional failure due to the message below
-          print *, "  (skipped copy of declared reference due to a gfortran bug that would cause a segmentation fault)"
-        else
-#ifndef __GFORTRAN__
-          declared = object_t() ! compiling with gfortran generates a runtime error even when this line doesn't execute
-#endif
-          reference_to_declared = declared
-          test_passes = associated(original%ref, reference%ref) .and. associated(declared%ref, reference_to_declared%ref)
-        end if
+        declared = object_t() ! compiling with gfortran generates a runtime error even when this line doesn't execute
+        reference_to_declared = declared
+        test_passes = associated(original%ref, reference%ref) .and. associated(declared%ref, reference_to_declared%ref)
       end block
 #ifndef XLF
     end associate


### PR DESCRIPTION
`gfortran` passes all Smart-Pointers tests as of GCC 13.0.1 master branch commit [d7caf] dated 20230318, which dropped the number of test failures from six to zero!  This PR updates the documentation accordingly and removes a workaround that was required when running the test suite with previous versions of `gfortran`.

[d7caf]: https://github.com/gcc-mirror/gcc/commit/d7caf313525a46f200d7f5db1ba893f853774aee