### PR TITLE
test(shallow/smart_pointer): make free() elemental

### DIFF
--- a/test/shallow_m.f90
+++ b/test/shallow_m.f90
@@ -27,7 +27,7 @@ contains
         call shallow%start_counter
     end function
 
-    subroutine free(self)
+    impure elemental subroutine free(self)
         class(shallow_t), intent(inout) :: self
 
         deallocate(resource)

--- a/test/sp_smart_pointer_test_m.F90
+++ b/test/sp_smart_pointer_test_m.F90
@@ -56,7 +56,7 @@ contains
     call object%start_counter
   end function
 
-  subroutine free(self)
+  impure elemental subroutine free(self)
     class(object_t), intent(inout) :: self
 
     if (allocated(the_resource)) deallocate(the_resource)


### PR DESCRIPTION
This fix makes the `free` type-bound procedures in two tests `impure elemental` as required by the same-named overridden type-bound procedure in `sp_smart_pointer_t`.