### PR TITLE
Documentation: detail LLVM flang test results

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ respectively.
 
 To use Smart-Pointers, define a non-abstract derived type that 
 
-1. Extends Smart Pointer's `sp_smart_pointer_t` type,
+1. Extends Smart-Pointer's `sp_smart_pointer_t` type,
 2. Implements the inherited `free` deferred binding, and
 3. Invokes the inherited `start_count` procedure inside object constructors.
 
@@ -61,25 +61,24 @@ Supported Compilers
 Correct execution of the Smart Pointers library depends critically on comprehensive
 compiler support for type finalization.  The unit test suite verifies the relevant
 compiler standard-conformance, including a test for each scenario in which the
-the Fortran 2018 standard requires that an object be finalized.  The table below
+the Fortran 2023 standard requires that an object be finalized.  The table below
 summarizes the observed compiler behaviors:
 
-| _Compiler_              | _Test failures_    | _Version tested_                                  |
-| :---                    |       :---:        | :---                                              |
-| AMD `flang`             | N.A. (see Note 1.) | 13.0.0 (AOCC_3.2.0-Build\#128 2021\_11\_12)       |
-| Cray `ftn`              | >= 3 (see Note 2.) | 13.0.1                                            |
-| GCC `gfortran` :trophy: | 0                  | 13.1.0                                            |
-| IBM `xlf2008_r`         | 1                  | 17.1.0 on AIX                                     |
-| Intel `ifort`           | 1                  | 2021.7.0 Build 20220726_000000                    |
-| Intel `ifx`             | 1                  | 2024.0.0 Build 20231017                           |
-| LLVM `flang` :trophy:   | 0                  | `git` commit `f5253058144aca1e9fcacd` (9/20/2022) |
-| NAG `nagfor` :trophy:   | 0                  | 7.1 Build 7113                                    |
-| NVIDIA `nvfortran`      | 2                  |  22.7-0                                           |
+| _Compiler_              | _Test failures_    | _Version tested_                            |
+| :---                    |       :---:        | :---                                        |
+| AMD `flang`             | N.A. (see Note 1.) | 13.0.0 (AOCC_3.2.0-Build\#128 2021\_11\_12) |
+| Cray `ftn`              | >= 3 (see Note 2.) | 13.0.1                                      |
+| GCC `gfortran` :trophy: | 0                  | 13.1.0                                      |
+| IBM `xlf2008_r`         | 1                  | 17.1.0 on AIX                               |
+| Intel `ifort`           | 1                  | 2021.7.0 Build 20220726_000000              |
+| Intel `ifx`             | 1                  | 2024.0.0 Build 20231017                     |
+| LLVM `flang` :trophy:   | 0                  | 19.0.0 `git` commit 325f5123                |
+| NAG `nagfor` :trophy:   | 0                  | 7.1 Build 7113                              |
+| NVIDIA `nvfortran`      | 2                  | 22.7-0                                      |
 
 **Notes**
 1. Fails to build due to an internal compiler error (ICE).
 2. Fails to build due to `fpm` issue [767]. See [test/README.md#cray] for a lower bound on the Cray compiler test failures.
-3. Fails to build due to polymorphism not yet being supported. However, a refactored version of the 10 compiler tests in [./tests/compiler_test_m.f90] pass when incorporated into the [llvm-test-suite].
 
 See the [test suite README.md](./test/README.md) for more details on each compiler's test
 results.

--- a/test/README.md
+++ b/test/README.md
@@ -153,8 +153,28 @@ Project is up to date
 ```
 
 ### LLVM
-- Version tested: `git` commit `76911b5f75907eef53a30cc3` (9/20/2022)
-- Result: Fails with the error message `not yet implemented: derived type finalization`
+- Version tested: 19.0.0 git commit 325f51237252e6dab8e4e1ea1fa7acbb4faee1cd
+- Result: 0 test failures. :trophy:
+```
+The compiler
+   Pass: finalizes a non-allocatable object on the LHS of an intrinsic assignme
+ nt
+   Pass: finalizes an allocated allocatable LHS of an intrinsic assignment
+   Pass: finalizes a target when the associated pointer is deallocated
+   Pass: finalizes an object upon explicit deallocation
+   Pass: finalizes a non-pointer non-allocatable object at the END statement
+   Pass: finalizes a non-pointer non-allocatable object at END BLOCK statement
+   Pass: finalizes a function reference on the RHS of an intrinsic assignment
+   Pass: finalizes a specification expression function result
+   Pass: finalizes an intent(out) derived type dummy argument
+   Pass: finalizes an allocatable component object
+
+ A smart_pointer
+   Pass: creates a resource when constructed
+   Pass: removes the resource when the object goes out of scope
+   Pass: copy points to the same resource as the original
+   Pass: has zero references after a shallow copy goes out of scope
+```
 
 ### NAG 
 - Version: 7.1 (Build 7113)


### PR DESCRIPTION
Upate `README.md` and `test/README.md` with detailed results of `flang-new` test results.