### PR TITLE
Make `fpm test` fail if any tests fail

### DIFF
--- a/test/main.f90
+++ b/test/main.f90
@@ -1,11 +1,13 @@
 program main
-  use compiler_test_m, only : compiler_test_t 
+  use compiler_test_m, only : compiler_test_t
   use sp_smart_pointer_test_m, only : sp_smart_pointer_test_t
   implicit none
 
   type(compiler_test_t) compiler_test
   type(sp_smart_pointer_test_t) sp_smart_pointer_test
+  integer :: failures
 
-  call compiler_test%report()
-  call sp_smart_pointer_test%report()
+  failures = compiler_test%report()
+  failures = failures + sp_smart_pointer_test%report()
+  if (failures > 0) error stop
 end program

--- a/test/test_m.F90
+++ b/test/test_m.F90
@@ -28,10 +28,11 @@ module test_m
 
   interface
 
-    module subroutine report(test)
+    module function report(test) result(failures)
       implicit none
       class(test_t), intent(in) :: test
-    end subroutine
+      integer :: failures
+    end function
 
   end interface
 
@@ -49,12 +50,14 @@ contains
     integer i
     type(test_result_t), allocatable :: test_results(:)
 
+    failures = 0
     print *
     print *, test%subject()
 
     test_results = test%results()
     do i=1,size(test_results)
       print *,"  ",test_results(i)%characterize()
+      if (.not. test_results(i)%outcome()) failures = failures + 1
     end do
   end procedure
 

--- a/test/test_result_m.f90
+++ b/test/test_result_m.f90
@@ -11,6 +11,7 @@ module test_result_m
     logical outcome_
   contains
     procedure :: characterize
+    procedure :: outcome
   end type
 
   interface test_result_t
@@ -32,6 +33,12 @@ module test_result_m
       character(len=:), allocatable :: characterization
     end function
 
+    pure module function outcome(self) result(passes)
+      implicit none
+      class(test_result_t), intent(in) :: self
+      logical :: passes
+    end function
+
   end interface
 
 end module test_result_m
@@ -48,6 +55,10 @@ contains
 
     module procedure characterize
       characterization = merge("Pass: ", "Fail: ", self%outcome_) // self%description_
+    end procedure
+
+    module procedure outcome
+      passes = self%outcome_
     end procedure
 
 end submodule test_result_s


### PR DESCRIPTION
That way if any test fails, we get a non-zero exit code from `fpm test`, which allows to hard fail in any script or CI running it, to easily see failures and regressions.